### PR TITLE
Alter commands on reload.

### DIFF
--- a/src/main/java/com/github/tjeukayim/commandpermissionsfabric/PermissionsMod.java
+++ b/src/main/java/com/github/tjeukayim/commandpermissionsfabric/PermissionsMod.java
@@ -38,6 +38,22 @@ public class PermissionsMod implements ModInitializer {
             }
             LOGGER.info("Loaded Minecraft Command Permissions");
         });
+
+        ServerLifecycleEvents.END_DATA_PACK_RELOAD.register((server, resourceManager, success) -> {
+            var dispatcher = server.getCommandManager().getDispatcher();
+            if ("true".equals(System.getenv("minecraft-command-permissions.test"))) {
+                var allCommands = dispatcher.getRoot().getChildren()
+                        .stream()
+                        .map(c -> "\"" + c.getName() + "\",")
+                        .sorted()
+                        .collect(Collectors.joining("\n"));
+                LOGGER.info("All commands:\n{}", allCommands);
+            }
+            for (CommandNode<ServerCommandSource> node : dispatcher.getRoot().getChildren()) {
+                alterCommand(node);
+            }
+            LOGGER.info("Reloaded Minecraft Command Permissions");
+        });
     }
 
     private void alterCommand(CommandNode<ServerCommandSource> child) {


### PR DESCRIPTION
There is currently a bug where permissions are no longer applied after ```/reload``` is run.
This PR fixes that by registering the event ```ServerLifecycleEvents.END_DATA_PACK_RELOAD``` in addition to the preexisting event ```ServerLifecycleEvents.SERVER_STARTING```.