### PR TITLE
Update to 1.19

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,15 +55,19 @@ minecraft.command.give            minecraft.command.setblock
 minecraft.command.help            minecraft.command.setidletimeout
 ```
 
-And since Minecraft 1.17 also this one:
-
+Minecraft 1.17 adds the following permissions:
 ```txt
 minecraft.command.item
 ```
 
-With Minecraft 1.18 you'll get this one too:
-```
+Minecraft 1.18 adds the following permissions:
+```txt
 minecraft.command.jfr
+```
+
+Minecraft 1.19 adds the following permissions:
+```txt
+minecraft.command.place
 ```
 
 ## Limitations

--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-	id 'fabric-loom' version '0.10-SNAPSHOT'
+	id 'fabric-loom' version '0.12-SNAPSHOT'
 	id 'maven-publish'
 }
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -2,16 +2,15 @@
 org.gradle.jvmargs=-Xmx1G
 
 # Fabric Properties
-	# check these on https://fabricmc.net/use
-	minecraft_version=1.18
-	yarn_mappings=1.18+build.1
-	loader_version=0.12.8
+	# check these on https://fabricmc.net/develop/
+	minecraft_version=1.19-pre5
+	yarn_mappings=1.19-pre5+build.3
+	loader_version=0.14.6
 
 # Mod Properties
-	mod_version = 1.5.0
+	mod_version = 1.6.0
 	maven_group = com.github.tjeukayim
 	archives_base_name = minecraft-command-permissions
 
 # Dependencies
-	# currently not on the main fabric site, check on the maven: https://maven.fabricmc.net/net/fabricmc/fabric-api/fabric-api
-	fabric_version=0.43.1+1.18
+	fabric_version=0.54.0+1.19

--- a/gradle.properties
+++ b/gradle.properties
@@ -3,9 +3,9 @@ org.gradle.jvmargs=-Xmx1G
 
 # Fabric Properties
 	# check these on https://fabricmc.net/develop/
-	minecraft_version=1.19-pre5
-	yarn_mappings=1.19-pre5+build.3
-	loader_version=0.14.6
+	minecraft_version=1.19
+	yarn_mappings=1.19+build.4
+	loader_version=0.14.8
 
 # Mod Properties
 	mod_version = 1.6.0
@@ -13,4 +13,4 @@ org.gradle.jvmargs=-Xmx1G
 	archives_base_name = minecraft-command-permissions
 
 # Dependencies
-	fabric_version=0.54.0+1.19
+	fabric_version=0.56.0+1.19

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -27,7 +27,7 @@
   "depends": {
     "fabricloader": ">=0.12.8",
     "fabric": "*",
-    "minecraft": "1.18.x",
+    "minecraft": "1.19.x",
     "fabric-permissions-api-v0": "*",
     "java": ">=17"
   },


### PR DESCRIPTION
Similar to #12, this PR prepares the mod for Minecraft 1.19. It currently targets 1.19-pre5 and Fabric API 0.54, and updates loom to 0.12-SNAPSHOT. I am not expecting any major changes between now and June 7th, so when 1.19 is released, gradle.properties can be bumped and this PR can be merged.

![image](https://user-images.githubusercontent.com/858456/171451231-0aaa73ac-a3d4-4471-8558-78b74f21afbb.png)
