### PR TITLE
More permissions

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -12,6 +12,7 @@ group = project.maven_group
 
 repositories {
 	maven { url 'https://oss.sonatype.org/content/repositories/snapshots' }
+	maven { url 'https://jitpack.io' } // MixinExtras
 }
 
 loom {
@@ -31,7 +32,12 @@ dependencies {
 		modImplementation(fabricApi.module(it, project.fabric_version))
 	}
 
-	modImplementation 'me.lucko:fabric-permissions-api:0.1-SNAPSHOT'
+	modImplementation "me.lucko:fabric-permissions-api:${project.fabric_permissions_version}"
+
+	// Mixin Extras
+	implementation "com.github.LlamaLad7:MixinExtras:${project.mixin_extras_version}"
+	include "com.github.LlamaLad7:MixinExtras:${project.mixin_extras_version}"
+	annotationProcessor "com.github.LlamaLad7:MixinExtras:${project.mixin_extras_version}"
 }
 
 processResources {

--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-	id 'fabric-loom' version '0.12-SNAPSHOT'
+	id 'fabric-loom' version '1.0-SNAPSHOT'
 	id 'maven-publish'
 }
 
@@ -12,6 +12,10 @@ group = project.maven_group
 
 repositories {
 	maven { url 'https://oss.sonatype.org/content/repositories/snapshots' }
+}
+
+loom {
+	accessWidenerPath.set(file("src/main/resources/mcpf.accesswidener"))
 }
 
 dependencies {

--- a/gradle.properties
+++ b/gradle.properties
@@ -3,9 +3,9 @@ org.gradle.jvmargs=-Xmx1G
 
 # Fabric Properties
 	# check these on https://fabricmc.net/develop/
-	minecraft_version=1.19
-	yarn_mappings=1.19+build.4
-	loader_version=0.14.8
+	minecraft_version=1.19.2
+	yarn_mappings=1.19.2+build.9
+	loader_version=0.14.9
 
 # Mod Properties
 	mod_version = 1.6.1
@@ -13,4 +13,4 @@ org.gradle.jvmargs=-Xmx1G
 	archives_base_name = minecraft-command-permissions
 
 # Dependencies
-	fabric_version=0.57.0+1.19
+	fabric_version=0.60.0+1.19.2

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,16 +1,15 @@
 # Done to increase the memory available to gradle.
 org.gradle.jvmargs=-Xmx1G
-
 # Fabric Properties
-	# check these on https://fabricmc.net/develop/
-	minecraft_version=1.19.2
-	yarn_mappings=1.19.2+build.9
-	loader_version=0.14.9
-
+# check these on https://fabricmc.net/develop/
+minecraft_version=1.19.2
+yarn_mappings=1.19.2+build.9
+loader_version=0.14.9
 # Mod Properties
-	mod_version = 1.7.0
-	maven_group = com.github.tjeukayim
-	archives_base_name = minecraft-command-permissions
-
+mod_version=1.7.0
+maven_group=com.github.tjeukayim
+archives_base_name=minecraft-command-permissions
 # Dependencies
-	fabric_version=0.60.0+1.19.2
+fabric_version=0.60.0+1.19.2
+fabric_permissions_version=0.2-SNAPSHOT
+mixin_extras_version=0.1.0-rc5

--- a/gradle.properties
+++ b/gradle.properties
@@ -8,7 +8,7 @@ org.gradle.jvmargs=-Xmx1G
 	loader_version=0.14.9
 
 # Mod Properties
-	mod_version = 1.6.1
+	mod_version = 1.7.0
 	maven_group = com.github.tjeukayim
 	archives_base_name = minecraft-command-permissions
 

--- a/src/main/java/com/github/tjeukayim/commandpermissionsfabric/Constants.java
+++ b/src/main/java/com/github/tjeukayim/commandpermissionsfabric/Constants.java
@@ -1,0 +1,49 @@
+package com.github.tjeukayim.commandpermissionsfabric;
+
+import net.minecraft.block.Block;
+import net.minecraft.item.Item;
+import net.minecraft.util.Identifier;
+import net.minecraft.util.registry.Registry;
+
+public class Constants {
+
+    public static final CharSequence DELIMITER = ".";
+    private static final String PREFIX = Identifier.DEFAULT_NAMESPACE;
+
+    public static final String BYPASS_SPAWN_PROTECTION = permission("bypass", "spawn-protection");
+    public static final String BYPASS_FORCE_GAMEMODE = permission("bypass", "force-gamemode");
+    public static final String BYPASS_MOVE_SPEED_PLAYER = permission("bypass", "move-speed", "player");
+    public static final String BYPASS_MOVE_SPEED_VEHICLE = permission("bypass", "move-speed", "vehicle", "%s", "%s");
+    public static final String BYPASS_CHAT_SPEED = permission("bypass", "chat-speed");
+    public static final String COMMAND = permission("command", "%s");
+    public static final String DEBUG_STICK_USE = permission("%s", "use", "%s", "%s");
+    public static final String NBT_QUERY_ENTITY = permission("nbt", "query", "entity");
+    public static final String NBT_QUERY_BLOCK = permission("nbt", "query", "block");
+    public static final String NBT_LOAD_ENTITY = permission("nbt", "load", "entity");
+    public static final String NBT_LOAD_BLOCK = permission("nbt", "load", "block");
+    public static final String OPERATOR_BLOCK_PLACE = permission("%s", "place");
+    public static final String OPERATOR_BLOCK_VIEW = permission("%s", "view");
+    public static final String OPERATOR_BLOCK_EDIT = permission("%s", "edit");
+    public static final String OPERATOR_BLOCK_BREAK = permission("%s", "break");
+    public static final String SELECTOR = permission("selector");
+
+    // Not yet implemented
+    public static final String BYPASS_WHITELIST = permission("bypass", "whitelist");
+    public static final String BYPASS_PLAYER_LIMIT = permission("bypass", "player-limit");
+
+    protected static String permission(String... parts) {
+        return build(PREFIX, build(parts));
+    }
+
+    public static String build(String... parts) {
+        return String.join(DELIMITER, parts);
+    }
+
+    public static String item(Item item) {
+        return Registry.ITEM.getId(item).getPath();
+    }
+
+    public static String block(Block block) {
+        return Registry.BLOCK.getId(block).getPath();
+    }
+}

--- a/src/main/java/com/github/tjeukayim/commandpermissionsfabric/PermissionsMod.java
+++ b/src/main/java/com/github/tjeukayim/commandpermissionsfabric/PermissionsMod.java
@@ -51,7 +51,7 @@ public class PermissionsMod implements DedicatedServerModInitializer {
         }
         LOGGER.debug("Alter command node {}", name);
         Predicate<ServerCommandSource> predicate = source -> Permissions.check(source, Constants.COMMAND.formatted(name));
-        ((CommandNodeAccessor<ServerCommandSource>) child).setRequirement(root ? child.getRequirement().or(predicate) : predicate);
+        ((CommandNodeAccessor<ServerCommandSource>) child).setRequirement(root ? child.getRequirement().or(predicate) : predicate.or(src -> src.hasPermissionLevel(2)));
         for (CommandNode<ServerCommandSource> childChild : child.getChildren()) {
             alterCommandNode(dispatcher, childChild, false);
         }

--- a/src/main/java/com/github/tjeukayim/commandpermissionsfabric/PermissionsMod.java
+++ b/src/main/java/com/github/tjeukayim/commandpermissionsfabric/PermissionsMod.java
@@ -2,7 +2,7 @@ package com.github.tjeukayim.commandpermissionsfabric;
 
 import com.mojang.brigadier.tree.CommandNode;
 import me.lucko.fabric.api.permissions.v0.Permissions;
-import net.fabricmc.api.ModInitializer;
+import net.fabricmc.api.DedicatedServerModInitializer;
 import net.fabricmc.fabric.api.command.v2.CommandRegistrationCallback;
 import net.minecraft.server.command.ServerCommandSource;
 import org.apache.logging.log4j.LogManager;
@@ -11,15 +11,14 @@ import org.apache.logging.log4j.Logger;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
 
-public class PermissionsMod implements ModInitializer {
+public class PermissionsMod implements DedicatedServerModInitializer {
     /**
      * Permission string prefix compatible with other modding frameworks.
      */
-    public static final String PREFIX = "minecraft.command.";
     private static final Logger LOGGER = LogManager.getLogger();
 
     @Override
-    public void onInitialize() {
+    public void onInitializeServer() {
         CommandRegistrationCallback.EVENT.register((dispatcher, registryAccess, environment) -> {
             if ("true".equals(System.getenv("minecraft-command-permissions.test"))) {
                 var allCommands = dispatcher.getRoot().getChildren()
@@ -48,7 +47,7 @@ public class PermissionsMod implements ModInitializer {
             var field = CommandNode.class.getDeclaredField("requirement");
             field.setAccessible(true);
             Predicate<ServerCommandSource> original = child.getRequirement();
-            field.set(child, original.or((source) -> Permissions.check(source, PREFIX + name, false)));
+            field.set(child, original.or((source) -> Permissions.check(source, Constants.COMMAND.formatted(name), false)));
         } catch (NoSuchFieldException | IllegalAccessException e) {
             LOGGER.warn("Failed to alter field CommandNode.requirement " + name, e);
         }

--- a/src/main/java/com/github/tjeukayim/commandpermissionsfabric/mixin/CommandNodeAccessor.java
+++ b/src/main/java/com/github/tjeukayim/commandpermissionsfabric/mixin/CommandNodeAccessor.java
@@ -1,0 +1,17 @@
+package com.github.tjeukayim.commandpermissionsfabric.mixin;
+
+import com.mojang.brigadier.tree.CommandNode;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Mutable;
+import org.spongepowered.asm.mixin.gen.Accessor;
+
+import java.util.function.Predicate;
+
+@Mixin(value = CommandNode.class, remap = false)
+public interface CommandNodeAccessor<S> {
+
+    @Accessor
+    @Mutable
+    void setRequirement(Predicate<S> predicate);
+
+}

--- a/src/main/java/com/github/tjeukayim/commandpermissionsfabric/mixin/ExecuteCommandMixin.java
+++ b/src/main/java/com/github/tjeukayim/commandpermissionsfabric/mixin/ExecuteCommandMixin.java
@@ -29,10 +29,11 @@ public abstract class ExecuteCommandMixin {
             at = @At(
                     value = "INVOKE",
                     target = "Lcom/mojang/brigadier/builder/LiteralArgumentBuilder;then(Lcom/mojang/brigadier/builder/ArgumentBuilder;)Lcom/mojang/brigadier/builder/ArgumentBuilder;",
+                    remap = false,
                     ordinal = 0
             )
     )
-    private static void addPermissionConditionArgument(
+    private static void mcpf_addPermissionConditionArgument(
             CommandNode<ServerCommandSource> root,
             LiteralArgumentBuilder<ServerCommandSource> argumentBuilder,
             boolean positive,

--- a/src/main/java/com/github/tjeukayim/commandpermissionsfabric/mixin/ExecuteCommandMixin.java
+++ b/src/main/java/com/github/tjeukayim/commandpermissionsfabric/mixin/ExecuteCommandMixin.java
@@ -24,8 +24,21 @@ public abstract class ExecuteCommandMixin {
         return null;
     }
 
-    @Inject(method = "addConditionArguments", at = @At(value = "INVOKE", target = "Lcom/mojang/brigadier/builder/LiteralArgumentBuilder;then(Lcom/mojang/brigadier/builder/ArgumentBuilder;)Lcom/mojang/brigadier/builder/ArgumentBuilder;", ordinal = 0))
-    private static void addPermissionConditionArgument(CommandNode<ServerCommandSource> root, LiteralArgumentBuilder<ServerCommandSource> argumentBuilder, boolean positive, CommandRegistryAccess commandRegistryAccess, CallbackInfoReturnable<ArgumentBuilder<ServerCommandSource, ?>> cir) {
+    @Inject(
+            method = "addConditionArguments",
+            at = @At(
+                    value = "INVOKE",
+                    target = "Lcom/mojang/brigadier/builder/LiteralArgumentBuilder;then(Lcom/mojang/brigadier/builder/ArgumentBuilder;)Lcom/mojang/brigadier/builder/ArgumentBuilder;",
+                    ordinal = 0
+            )
+    )
+    private static void addPermissionConditionArgument(
+            CommandNode<ServerCommandSource> root,
+            LiteralArgumentBuilder<ServerCommandSource> argumentBuilder,
+            boolean positive,
+            CommandRegistryAccess commandRegistryAccess,
+            CallbackInfoReturnable<ArgumentBuilder<ServerCommandSource, ?>> cir
+    ) {
         argumentBuilder.then(
                 CommandManager.literal("permission")
                         .then(

--- a/src/main/java/com/github/tjeukayim/commandpermissionsfabric/mixin/ExecuteCommandMixin.java
+++ b/src/main/java/com/github/tjeukayim/commandpermissionsfabric/mixin/ExecuteCommandMixin.java
@@ -1,0 +1,45 @@
+package com.github.tjeukayim.commandpermissionsfabric.mixin;
+
+import com.mojang.brigadier.arguments.StringArgumentType;
+import com.mojang.brigadier.builder.ArgumentBuilder;
+import com.mojang.brigadier.builder.LiteralArgumentBuilder;
+import com.mojang.brigadier.tree.CommandNode;
+import me.lucko.fabric.api.permissions.v0.Permissions;
+import net.minecraft.command.CommandRegistryAccess;
+import net.minecraft.command.argument.EntityArgumentType;
+import net.minecraft.server.command.CommandManager;
+import net.minecraft.server.command.ExecuteCommand;
+import net.minecraft.server.command.ServerCommandSource;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
+
+@Mixin(ExecuteCommand.class)
+public abstract class ExecuteCommandMixin {
+
+    @Shadow
+    private static ArgumentBuilder<ServerCommandSource, ?> addConditionLogic(CommandNode<ServerCommandSource> root, ArgumentBuilder<ServerCommandSource, ?> builder, boolean positive, ExecuteCommand.Condition condition) {
+        return null;
+    }
+
+    @Inject(method = "addConditionArguments", at = @At(value = "INVOKE", target = "Lcom/mojang/brigadier/builder/LiteralArgumentBuilder;then(Lcom/mojang/brigadier/builder/ArgumentBuilder;)Lcom/mojang/brigadier/builder/ArgumentBuilder;", ordinal = 0))
+    private static void addPermissionConditionArgument(CommandNode<ServerCommandSource> root, LiteralArgumentBuilder<ServerCommandSource> argumentBuilder, boolean positive, CommandRegistryAccess commandRegistryAccess, CallbackInfoReturnable<ArgumentBuilder<ServerCommandSource, ?>> cir) {
+        argumentBuilder.then(
+                CommandManager.literal("permission")
+                        .then(
+                                CommandManager.argument("entity", EntityArgumentType.entity())
+                                        .then(
+                                                addConditionLogic(
+                                                        root,
+                                                        CommandManager.argument("permission", StringArgumentType.word()),
+                                                        positive,
+                                                        context -> Permissions.check(EntityArgumentType.getEntity(context, "entity"), StringArgumentType.getString(context, "permission"))
+                                                )
+                                        )
+                        )
+        );
+    }
+
+}

--- a/src/main/java/com/github/tjeukayim/commandpermissionsfabric/mixin/PlayerManagerMixin.java
+++ b/src/main/java/com/github/tjeukayim/commandpermissionsfabric/mixin/PlayerManagerMixin.java
@@ -1,0 +1,23 @@
+package com.github.tjeukayim.commandpermissionsfabric.mixin;
+
+import net.minecraft.server.PlayerManager;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.ModifyArg;
+
+@Mixin(PlayerManager.class)
+public abstract class PlayerManagerMixin {
+
+    @ModifyArg(
+            method = "sendCommandTree(Lnet/minecraft/server/network/ServerPlayerEntity;)V",
+            at = @At(
+                    value = "INVOKE",
+                    target = "Lnet/minecraft/server/PlayerManager;sendCommandTree(Lnet/minecraft/server/network/ServerPlayerEntity;I)V"
+            ),
+            index = 1
+    )
+    public int sendOpLevelTwoOrHigher(int permissionLevel) {
+        return Math.max(2, permissionLevel);
+    }
+
+}

--- a/src/main/java/com/github/tjeukayim/commandpermissionsfabric/mixin/PlayerManagerMixin.java
+++ b/src/main/java/com/github/tjeukayim/commandpermissionsfabric/mixin/PlayerManagerMixin.java
@@ -16,7 +16,7 @@ public abstract class PlayerManagerMixin {
             ),
             index = 1
     )
-    public int sendOpLevelTwoOrHigher(int permissionLevel) {
+    public int mcpf_sendOpLevelTwoOrHigher(int permissionLevel) {
         return Math.max(2, permissionLevel);
     }
 

--- a/src/main/java/com/github/tjeukayim/commandpermissionsfabric/mixin/bypass/chat_speed/ServerPlayNetworkHandlerMixin.java
+++ b/src/main/java/com/github/tjeukayim/commandpermissionsfabric/mixin/bypass/chat_speed/ServerPlayNetworkHandlerMixin.java
@@ -1,0 +1,30 @@
+package com.github.tjeukayim.commandpermissionsfabric.mixin.bypass.chat_speed;
+
+import com.github.tjeukayim.commandpermissionsfabric.Constants;
+import com.mojang.authlib.GameProfile;
+import me.lucko.fabric.api.permissions.v0.Permissions;
+import net.minecraft.server.PlayerManager;
+import net.minecraft.server.network.ServerPlayNetworkHandler;
+import net.minecraft.server.network.ServerPlayerEntity;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Redirect;
+
+@Mixin(ServerPlayNetworkHandler.class)
+public abstract class ServerPlayNetworkHandlerMixin {
+
+    @Shadow
+    public ServerPlayerEntity player;
+
+    @Redirect(
+            method = "checkForSpam",
+            at = @At(
+                    value = "INVOKE",
+                    target = "Lnet/minecraft/server/PlayerManager;isOperator(Lcom/mojang/authlib/GameProfile;)Z"
+            )
+    )
+    public boolean addBypassChatSpeedPermission(PlayerManager playerManager, GameProfile profile) {
+        return Permissions.check(this.player, Constants.BYPASS_CHAT_SPEED) || playerManager.isOperator(profile);
+    }
+}

--- a/src/main/java/com/github/tjeukayim/commandpermissionsfabric/mixin/bypass/chat_speed/ServerPlayNetworkHandlerMixin.java
+++ b/src/main/java/com/github/tjeukayim/commandpermissionsfabric/mixin/bypass/chat_speed/ServerPlayNetworkHandlerMixin.java
@@ -1,15 +1,13 @@
 package com.github.tjeukayim.commandpermissionsfabric.mixin.bypass.chat_speed;
 
 import com.github.tjeukayim.commandpermissionsfabric.Constants;
-import com.mojang.authlib.GameProfile;
+import com.llamalad7.mixinextras.injector.ModifyExpressionValue;
 import me.lucko.fabric.api.permissions.v0.Permissions;
-import net.minecraft.server.PlayerManager;
 import net.minecraft.server.network.ServerPlayNetworkHandler;
 import net.minecraft.server.network.ServerPlayerEntity;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.asm.mixin.injection.At;
-import org.spongepowered.asm.mixin.injection.Redirect;
 
 @Mixin(ServerPlayNetworkHandler.class)
 public abstract class ServerPlayNetworkHandlerMixin {
@@ -17,14 +15,15 @@ public abstract class ServerPlayNetworkHandlerMixin {
     @Shadow
     public ServerPlayerEntity player;
 
-    @Redirect(
+    @ModifyExpressionValue(
             method = "checkForSpam",
             at = @At(
                     value = "INVOKE",
                     target = "Lnet/minecraft/server/PlayerManager;isOperator(Lcom/mojang/authlib/GameProfile;)Z"
             )
     )
-    public boolean addBypassChatSpeedPermission(PlayerManager playerManager, GameProfile profile) {
-        return Permissions.check(this.player, Constants.BYPASS_CHAT_SPEED) || playerManager.isOperator(profile);
+    public boolean mcpf_addBypassChatSpeedPermission(boolean original) {
+        return Permissions.check(this.player, Constants.BYPASS_CHAT_SPEED) || original;
     }
+
 }

--- a/src/main/java/com/github/tjeukayim/commandpermissionsfabric/mixin/bypass/force_gamemode/DefaultGameModeCommandMixin.java
+++ b/src/main/java/com/github/tjeukayim/commandpermissionsfabric/mixin/bypass/force_gamemode/DefaultGameModeCommandMixin.java
@@ -1,0 +1,29 @@
+package com.github.tjeukayim.commandpermissionsfabric.mixin.bypass.force_gamemode;
+
+import com.github.tjeukayim.commandpermissionsfabric.Constants;
+import me.lucko.fabric.api.permissions.v0.Permissions;
+import net.minecraft.server.command.DefaultGameModeCommand;
+import net.minecraft.server.network.ServerPlayerEntity;
+import net.minecraft.world.GameMode;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Redirect;
+
+@Mixin(DefaultGameModeCommand.class)
+public abstract class DefaultGameModeCommandMixin {
+
+    @Redirect(
+            method = "execute",
+            at = @At(
+                    value = "INVOKE",
+                    target = "Lnet/minecraft/server/network/ServerPlayerEntity;changeGameMode(Lnet/minecraft/world/GameMode;)Z"
+            )
+    )
+    private static boolean addDefaultGameModeOverridePermission(ServerPlayerEntity playerEntity, GameMode gameMode) {
+        if (Permissions.check(playerEntity, Constants.BYPASS_FORCE_GAMEMODE)) {
+            return false;
+        }
+        return playerEntity.changeGameMode(gameMode);
+    }
+
+}

--- a/src/main/java/com/github/tjeukayim/commandpermissionsfabric/mixin/bypass/force_gamemode/DefaultGameModeCommandMixin.java
+++ b/src/main/java/com/github/tjeukayim/commandpermissionsfabric/mixin/bypass/force_gamemode/DefaultGameModeCommandMixin.java
@@ -1,29 +1,30 @@
 package com.github.tjeukayim.commandpermissionsfabric.mixin.bypass.force_gamemode;
 
 import com.github.tjeukayim.commandpermissionsfabric.Constants;
+import com.llamalad7.mixinextras.injector.wrapoperation.Operation;
+import com.llamalad7.mixinextras.injector.wrapoperation.WrapOperation;
 import me.lucko.fabric.api.permissions.v0.Permissions;
 import net.minecraft.server.command.DefaultGameModeCommand;
 import net.minecraft.server.network.ServerPlayerEntity;
 import net.minecraft.world.GameMode;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
-import org.spongepowered.asm.mixin.injection.Redirect;
 
 @Mixin(DefaultGameModeCommand.class)
 public abstract class DefaultGameModeCommandMixin {
 
-    @Redirect(
+    @WrapOperation(
             method = "execute",
             at = @At(
                     value = "INVOKE",
                     target = "Lnet/minecraft/server/network/ServerPlayerEntity;changeGameMode(Lnet/minecraft/world/GameMode;)Z"
             )
     )
-    private static boolean addDefaultGameModeOverridePermission(ServerPlayerEntity playerEntity, GameMode gameMode) {
-        if (Permissions.check(playerEntity, Constants.BYPASS_FORCE_GAMEMODE)) {
+    private static boolean mcpf_addDefaultGameModeOverridePermission(ServerPlayerEntity player, GameMode gameMode, Operation<Boolean> original) {
+        if (Permissions.check(player, Constants.BYPASS_FORCE_GAMEMODE)) {
             return false;
         }
-        return playerEntity.changeGameMode(gameMode);
+        return original.call(player, gameMode);
     }
 
 }

--- a/src/main/java/com/github/tjeukayim/commandpermissionsfabric/mixin/bypass/force_gamemode/ServerPlayerEntityMixin.java
+++ b/src/main/java/com/github/tjeukayim/commandpermissionsfabric/mixin/bypass/force_gamemode/ServerPlayerEntityMixin.java
@@ -1,0 +1,40 @@
+package com.github.tjeukayim.commandpermissionsfabric.mixin.bypass.force_gamemode;
+
+import com.github.tjeukayim.commandpermissionsfabric.Constants;
+import com.mojang.authlib.GameProfile;
+import me.lucko.fabric.api.permissions.v0.Permissions;
+import net.minecraft.entity.player.PlayerEntity;
+import net.minecraft.network.encryption.PlayerPublicKey;
+import net.minecraft.server.MinecraftServer;
+import net.minecraft.server.network.ServerPlayerEntity;
+import net.minecraft.util.math.BlockPos;
+import net.minecraft.world.GameMode;
+import net.minecraft.world.World;
+import org.jetbrains.annotations.Nullable;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Redirect;
+
+@Mixin(ServerPlayerEntity.class)
+public abstract class ServerPlayerEntityMixin extends PlayerEntity {
+
+    public ServerPlayerEntityMixin(World world, BlockPos pos, float yaw, GameProfile gameProfile, @Nullable PlayerPublicKey publicKey) {
+        super(world, pos, yaw, gameProfile, publicKey);
+    }
+
+    @Redirect(
+            method = "getServerGameMode",
+            at = @At(
+                    value = "INVOKE",
+                    target = "Lnet/minecraft/server/MinecraftServer;getForcedGameMode()Lnet/minecraft/world/GameMode;"
+            )
+    )
+    public GameMode addDefaultGameModeOverridePermission(MinecraftServer minecraftServer) {
+        if (Permissions.check(this, Constants.BYPASS_FORCE_GAMEMODE)) {
+            return null;
+        } else {
+            return minecraftServer.getForcedGameMode();
+        }
+    }
+
+}

--- a/src/main/java/com/github/tjeukayim/commandpermissionsfabric/mixin/bypass/force_gamemode/ServerPlayerEntityMixin.java
+++ b/src/main/java/com/github/tjeukayim/commandpermissionsfabric/mixin/bypass/force_gamemode/ServerPlayerEntityMixin.java
@@ -1,39 +1,30 @@
 package com.github.tjeukayim.commandpermissionsfabric.mixin.bypass.force_gamemode;
 
 import com.github.tjeukayim.commandpermissionsfabric.Constants;
-import com.mojang.authlib.GameProfile;
+import com.llamalad7.mixinextras.injector.wrapoperation.Operation;
+import com.llamalad7.mixinextras.injector.wrapoperation.WrapOperation;
 import me.lucko.fabric.api.permissions.v0.Permissions;
-import net.minecraft.entity.player.PlayerEntity;
-import net.minecraft.network.encryption.PlayerPublicKey;
 import net.minecraft.server.MinecraftServer;
 import net.minecraft.server.network.ServerPlayerEntity;
-import net.minecraft.util.math.BlockPos;
 import net.minecraft.world.GameMode;
-import net.minecraft.world.World;
-import org.jetbrains.annotations.Nullable;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
-import org.spongepowered.asm.mixin.injection.Redirect;
 
 @Mixin(ServerPlayerEntity.class)
-public abstract class ServerPlayerEntityMixin extends PlayerEntity {
+public abstract class ServerPlayerEntityMixin {
 
-    public ServerPlayerEntityMixin(World world, BlockPos pos, float yaw, GameProfile gameProfile, @Nullable PlayerPublicKey publicKey) {
-        super(world, pos, yaw, gameProfile, publicKey);
-    }
-
-    @Redirect(
+    @WrapOperation(
             method = "getServerGameMode",
             at = @At(
                     value = "INVOKE",
                     target = "Lnet/minecraft/server/MinecraftServer;getForcedGameMode()Lnet/minecraft/world/GameMode;"
             )
     )
-    public GameMode addDefaultGameModeOverridePermission(MinecraftServer minecraftServer) {
-        if (Permissions.check(this, Constants.BYPASS_FORCE_GAMEMODE)) {
+    public GameMode mcpf_addDefaultGameModeOverridePermission(MinecraftServer minecraftServer, Operation<GameMode> original) {
+        if (Permissions.check((ServerPlayerEntity) (Object) this, Constants.BYPASS_FORCE_GAMEMODE)) {
             return null;
         } else {
-            return minecraftServer.getForcedGameMode();
+            return original.call(minecraftServer);
         }
     }
 

--- a/src/main/java/com/github/tjeukayim/commandpermissionsfabric/mixin/bypass/move_speed/ServerPlayNetworkHandlerMixin.java
+++ b/src/main/java/com/github/tjeukayim/commandpermissionsfabric/mixin/bypass/move_speed/ServerPlayNetworkHandlerMixin.java
@@ -1,41 +1,42 @@
 package com.github.tjeukayim.commandpermissionsfabric.mixin.bypass.move_speed;
 
 import com.github.tjeukayim.commandpermissionsfabric.Constants;
+import com.llamalad7.mixinextras.injector.ModifyExpressionValue;
 import me.lucko.fabric.api.permissions.v0.Permissions;
 import net.minecraft.server.network.ServerPlayNetworkHandler;
+import net.minecraft.server.network.ServerPlayerEntity;
 import net.minecraft.util.Identifier;
 import net.minecraft.util.registry.Registry;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.asm.mixin.injection.At;
-import org.spongepowered.asm.mixin.injection.Redirect;
 
 @Mixin(ServerPlayNetworkHandler.class)
 public abstract class ServerPlayNetworkHandlerMixin {
 
     @Shadow
-    protected abstract boolean isHost();
+    public ServerPlayerEntity player;
 
-    @Redirect(
+    @ModifyExpressionValue(
             method = "onPlayerMove",
             at = @At(
                     value = "INVOKE",
                     target = "Lnet/minecraft/server/network/ServerPlayNetworkHandler;isHost()Z"
             )
     )
-    public boolean addBypassMoveSpeedPlayerPermission(ServerPlayNetworkHandler networkHandler) {
-        return Permissions.check(networkHandler.player, Constants.BYPASS_MOVE_SPEED_PLAYER) || this.isHost();
+    public boolean mcpf_addBypassMoveSpeedPlayerPermission(boolean original) {
+        return Permissions.check(this.player, Constants.BYPASS_MOVE_SPEED_PLAYER) || original;
     }
 
-    @Redirect(
+    @ModifyExpressionValue(
             method = "onVehicleMove",
             at = @At(
                     value = "INVOKE",
                     target = "Lnet/minecraft/server/network/ServerPlayNetworkHandler;isHost()Z"
             )
     )
-    public boolean addBypassMoveSpeedVehiclePermission(ServerPlayNetworkHandler networkHandler) {
-        Identifier identifier = Registry.ENTITY_TYPE.getId(networkHandler.player.getRootVehicle().getType());
-        return Permissions.check(networkHandler.player, Constants.BYPASS_MOVE_SPEED_VEHICLE.formatted(identifier.getNamespace(), identifier.getPath())) || this.isHost();
+    public boolean mcpf_addBypassMoveSpeedVehiclePermission(boolean original) {
+        Identifier identifier = Registry.ENTITY_TYPE.getId(this.player.getRootVehicle().getType());
+        return Permissions.check(this.player, Constants.BYPASS_MOVE_SPEED_VEHICLE.formatted(identifier.getNamespace(), identifier.getPath())) || original;
     }
 }

--- a/src/main/java/com/github/tjeukayim/commandpermissionsfabric/mixin/bypass/move_speed/ServerPlayNetworkHandlerMixin.java
+++ b/src/main/java/com/github/tjeukayim/commandpermissionsfabric/mixin/bypass/move_speed/ServerPlayNetworkHandlerMixin.java
@@ -1,0 +1,41 @@
+package com.github.tjeukayim.commandpermissionsfabric.mixin.bypass.move_speed;
+
+import com.github.tjeukayim.commandpermissionsfabric.Constants;
+import me.lucko.fabric.api.permissions.v0.Permissions;
+import net.minecraft.server.network.ServerPlayNetworkHandler;
+import net.minecraft.util.Identifier;
+import net.minecraft.util.registry.Registry;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Redirect;
+
+@Mixin(ServerPlayNetworkHandler.class)
+public abstract class ServerPlayNetworkHandlerMixin {
+
+    @Shadow
+    protected abstract boolean isHost();
+
+    @Redirect(
+            method = "onPlayerMove",
+            at = @At(
+                    value = "INVOKE",
+                    target = "Lnet/minecraft/server/network/ServerPlayNetworkHandler;isHost()Z"
+            )
+    )
+    public boolean addBypassMoveSpeedPlayerPermission(ServerPlayNetworkHandler networkHandler) {
+        return Permissions.check(networkHandler.player, Constants.BYPASS_MOVE_SPEED_PLAYER) || this.isHost();
+    }
+
+    @Redirect(
+            method = "onVehicleMove",
+            at = @At(
+                    value = "INVOKE",
+                    target = "Lnet/minecraft/server/network/ServerPlayNetworkHandler;isHost()Z"
+            )
+    )
+    public boolean addBypassMoveSpeedVehiclePermission(ServerPlayNetworkHandler networkHandler) {
+        Identifier identifier = Registry.ENTITY_TYPE.getId(networkHandler.player.getRootVehicle().getType());
+        return Permissions.check(networkHandler.player, Constants.BYPASS_MOVE_SPEED_VEHICLE.formatted(identifier.getNamespace(), identifier.getPath())) || this.isHost();
+    }
+}

--- a/src/main/java/com/github/tjeukayim/commandpermissionsfabric/mixin/bypass/spawn_protection/MinecraftDedicatedServerMixin.java
+++ b/src/main/java/com/github/tjeukayim/commandpermissionsfabric/mixin/bypass/spawn_protection/MinecraftDedicatedServerMixin.java
@@ -1,29 +1,27 @@
 package com.github.tjeukayim.commandpermissionsfabric.mixin.bypass.spawn_protection;
 
 import com.github.tjeukayim.commandpermissionsfabric.Constants;
-import com.mojang.authlib.GameProfile;
+import com.llamalad7.mixinextras.injector.ModifyExpressionValue;
 import me.lucko.fabric.api.permissions.v0.Permissions;
 import net.minecraft.entity.player.PlayerEntity;
-import net.minecraft.server.dedicated.DedicatedPlayerManager;
 import net.minecraft.server.dedicated.MinecraftDedicatedServer;
 import net.minecraft.server.world.ServerWorld;
 import net.minecraft.util.math.BlockPos;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
-import org.spongepowered.asm.mixin.injection.Redirect;
 
 @Mixin(MinecraftDedicatedServer.class)
 public abstract class MinecraftDedicatedServerMixin {
 
-    @Redirect(
+    @ModifyExpressionValue(
             method = "isSpawnProtected",
             at = @At(
                     value = "INVOKE",
                     target = "Lnet/minecraft/server/dedicated/DedicatedPlayerManager;isOperator(Lcom/mojang/authlib/GameProfile;)Z"
             )
     )
-    public boolean addSpawnProtectionPermission(DedicatedPlayerManager playerManager, GameProfile gameProfile, ServerWorld world, BlockPos pos, PlayerEntity player) {
-        return Permissions.check(player, Constants.BYPASS_SPAWN_PROTECTION) || playerManager.isOperator(gameProfile);
+    public boolean mcpf_addSpawnProtectionPermission(boolean original, ServerWorld world, BlockPos pos, PlayerEntity player) {
+        return Permissions.check(player, Constants.BYPASS_SPAWN_PROTECTION) || original;
     }
 
 }

--- a/src/main/java/com/github/tjeukayim/commandpermissionsfabric/mixin/bypass/spawn_protection/MinecraftDedicatedServerMixin.java
+++ b/src/main/java/com/github/tjeukayim/commandpermissionsfabric/mixin/bypass/spawn_protection/MinecraftDedicatedServerMixin.java
@@ -1,0 +1,29 @@
+package com.github.tjeukayim.commandpermissionsfabric.mixin.bypass.spawn_protection;
+
+import com.github.tjeukayim.commandpermissionsfabric.Constants;
+import com.mojang.authlib.GameProfile;
+import me.lucko.fabric.api.permissions.v0.Permissions;
+import net.minecraft.entity.player.PlayerEntity;
+import net.minecraft.server.dedicated.DedicatedPlayerManager;
+import net.minecraft.server.dedicated.MinecraftDedicatedServer;
+import net.minecraft.server.world.ServerWorld;
+import net.minecraft.util.math.BlockPos;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Redirect;
+
+@Mixin(MinecraftDedicatedServer.class)
+public abstract class MinecraftDedicatedServerMixin {
+
+    @Redirect(
+            method = "isSpawnProtected",
+            at = @At(
+                    value = "INVOKE",
+                    target = "Lnet/minecraft/server/dedicated/DedicatedPlayerManager;isOperator(Lcom/mojang/authlib/GameProfile;)Z"
+            )
+    )
+    public boolean addSpawnProtectionPermission(DedicatedPlayerManager playerManager, GameProfile gameProfile, ServerWorld world, BlockPos pos, PlayerEntity player) {
+        return Permissions.check(player, Constants.BYPASS_SPAWN_PROTECTION) || playerManager.isOperator(gameProfile);
+    }
+
+}

--- a/src/main/java/com/github/tjeukayim/commandpermissionsfabric/mixin/debugstick/DebugStickItemMixin.java
+++ b/src/main/java/com/github/tjeukayim/commandpermissionsfabric/mixin/debugstick/DebugStickItemMixin.java
@@ -1,0 +1,32 @@
+package com.github.tjeukayim.commandpermissionsfabric.mixin.debugstick;
+
+import com.github.tjeukayim.commandpermissionsfabric.Constants;
+import me.lucko.fabric.api.permissions.v0.Permissions;
+import net.minecraft.block.BlockState;
+import net.minecraft.entity.player.PlayerEntity;
+import net.minecraft.item.DebugStickItem;
+import net.minecraft.item.Items;
+import net.minecraft.util.Identifier;
+import net.minecraft.util.registry.Registry;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Redirect;
+
+import static com.github.tjeukayim.commandpermissionsfabric.Constants.item;
+
+@Mixin(DebugStickItem.class)
+public abstract class DebugStickItemMixin {
+
+    @Redirect(
+            method = "use",
+            at = @At(
+                    value = "INVOKE",
+                    target = "Lnet/minecraft/entity/player/PlayerEntity;isCreativeLevelTwoOp()Z"
+            )
+    )
+    public boolean addDebugStickUsePermission(PlayerEntity playerEntity, PlayerEntity player, BlockState state) {
+        Identifier identifier = Registry.BLOCK.getId(state.getBlock());
+        return Permissions.check(playerEntity, Constants.DEBUG_STICK_USE.formatted(item(Items.DEBUG_STICK), identifier.getNamespace(), identifier.getPath())) || playerEntity.isCreativeLevelTwoOp();
+    }
+
+}

--- a/src/main/java/com/github/tjeukayim/commandpermissionsfabric/mixin/debugstick/DebugStickItemMixin.java
+++ b/src/main/java/com/github/tjeukayim/commandpermissionsfabric/mixin/debugstick/DebugStickItemMixin.java
@@ -1,6 +1,7 @@
 package com.github.tjeukayim.commandpermissionsfabric.mixin.debugstick;
 
 import com.github.tjeukayim.commandpermissionsfabric.Constants;
+import com.llamalad7.mixinextras.injector.ModifyExpressionValue;
 import me.lucko.fabric.api.permissions.v0.Permissions;
 import net.minecraft.block.BlockState;
 import net.minecraft.entity.player.PlayerEntity;
@@ -10,23 +11,22 @@ import net.minecraft.util.Identifier;
 import net.minecraft.util.registry.Registry;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
-import org.spongepowered.asm.mixin.injection.Redirect;
 
 import static com.github.tjeukayim.commandpermissionsfabric.Constants.item;
 
 @Mixin(DebugStickItem.class)
 public abstract class DebugStickItemMixin {
 
-    @Redirect(
+    @ModifyExpressionValue(
             method = "use",
             at = @At(
                     value = "INVOKE",
                     target = "Lnet/minecraft/entity/player/PlayerEntity;isCreativeLevelTwoOp()Z"
             )
     )
-    public boolean addDebugStickUsePermission(PlayerEntity playerEntity, PlayerEntity player, BlockState state) {
+    public boolean mcpf_addDebugStickUsePermission(boolean original, PlayerEntity player, BlockState state) {
         Identifier identifier = Registry.BLOCK.getId(state.getBlock());
-        return Permissions.check(playerEntity, Constants.DEBUG_STICK_USE.formatted(item(Items.DEBUG_STICK), identifier.getNamespace(), identifier.getPath())) || playerEntity.isCreativeLevelTwoOp();
+        return Permissions.check(player, Constants.DEBUG_STICK_USE.formatted(item(Items.DEBUG_STICK), identifier.getNamespace(), identifier.getPath())) || original;
     }
 
 }

--- a/src/main/java/com/github/tjeukayim/commandpermissionsfabric/mixin/nbt/BlockItemMixin.java
+++ b/src/main/java/com/github/tjeukayim/commandpermissionsfabric/mixin/nbt/BlockItemMixin.java
@@ -1,0 +1,25 @@
+package com.github.tjeukayim.commandpermissionsfabric.mixin.nbt;
+
+import com.github.tjeukayim.commandpermissionsfabric.Constants;
+import me.lucko.fabric.api.permissions.v0.Permissions;
+import net.minecraft.entity.player.PlayerEntity;
+import net.minecraft.item.BlockItem;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Redirect;
+
+@Mixin(BlockItem.class)
+public abstract class BlockItemMixin {
+
+    @Redirect(
+            method = "writeNbtToBlockEntity",
+            at = @At(
+                    value = "INVOKE",
+                    target = "Lnet/minecraft/entity/player/PlayerEntity;isCreativeLevelTwoOp()Z"
+            )
+    )
+    private static boolean addNbtLoadBlockPermission(PlayerEntity playerEntity) {
+        return Permissions.check(playerEntity, Constants.NBT_LOAD_BLOCK) || playerEntity.isCreativeLevelTwoOp();
+    }
+
+}

--- a/src/main/java/com/github/tjeukayim/commandpermissionsfabric/mixin/nbt/BlockItemMixin.java
+++ b/src/main/java/com/github/tjeukayim/commandpermissionsfabric/mixin/nbt/BlockItemMixin.java
@@ -1,25 +1,26 @@
 package com.github.tjeukayim.commandpermissionsfabric.mixin.nbt;
 
 import com.github.tjeukayim.commandpermissionsfabric.Constants;
+import com.llamalad7.mixinextras.injector.ModifyExpressionValue;
 import me.lucko.fabric.api.permissions.v0.Permissions;
 import net.minecraft.entity.player.PlayerEntity;
 import net.minecraft.item.BlockItem;
+import net.minecraft.world.World;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
-import org.spongepowered.asm.mixin.injection.Redirect;
 
 @Mixin(BlockItem.class)
 public abstract class BlockItemMixin {
 
-    @Redirect(
+    @ModifyExpressionValue(
             method = "writeNbtToBlockEntity",
             at = @At(
                     value = "INVOKE",
                     target = "Lnet/minecraft/entity/player/PlayerEntity;isCreativeLevelTwoOp()Z"
             )
     )
-    private static boolean addNbtLoadBlockPermission(PlayerEntity playerEntity) {
-        return Permissions.check(playerEntity, Constants.NBT_LOAD_BLOCK) || playerEntity.isCreativeLevelTwoOp();
+    private static boolean mcpf_addNbtLoadBlockPermission(boolean original, World world, PlayerEntity player) {
+        return Permissions.check(player, Constants.NBT_LOAD_BLOCK) || original;
     }
 
 }

--- a/src/main/java/com/github/tjeukayim/commandpermissionsfabric/mixin/nbt/EntityTypeMixin.java
+++ b/src/main/java/com/github/tjeukayim/commandpermissionsfabric/mixin/nbt/EntityTypeMixin.java
@@ -1,27 +1,25 @@
 package com.github.tjeukayim.commandpermissionsfabric.mixin.nbt;
 
 import com.github.tjeukayim.commandpermissionsfabric.Constants;
-import com.mojang.authlib.GameProfile;
+import com.llamalad7.mixinextras.injector.ModifyExpressionValue;
 import me.lucko.fabric.api.permissions.v0.Permissions;
 import net.minecraft.entity.EntityType;
 import net.minecraft.entity.player.PlayerEntity;
-import net.minecraft.server.PlayerManager;
 import net.minecraft.world.World;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
-import org.spongepowered.asm.mixin.injection.Redirect;
 
 @Mixin(EntityType.class)
 public abstract class EntityTypeMixin {
 
-    @Redirect(
+    @ModifyExpressionValue(
             method = "loadFromEntityNbt",
             at = @At(
                     value = "INVOKE",
                     target = "Lnet/minecraft/server/PlayerManager;isOperator(Lcom/mojang/authlib/GameProfile;)Z"
             )
     )
-    private static boolean addNbtLoadEntityPermission(PlayerManager playerManager, GameProfile profile, World world, PlayerEntity playerEntity) {
-        return Permissions.check(playerEntity, Constants.NBT_LOAD_ENTITY) || playerManager.isOperator(profile);
+    private static boolean mcpf_addNbtLoadEntityPermission(boolean original, World world, PlayerEntity player) {
+        return Permissions.check(player, Constants.NBT_LOAD_ENTITY) || original;
     }
 }

--- a/src/main/java/com/github/tjeukayim/commandpermissionsfabric/mixin/nbt/EntityTypeMixin.java
+++ b/src/main/java/com/github/tjeukayim/commandpermissionsfabric/mixin/nbt/EntityTypeMixin.java
@@ -1,0 +1,27 @@
+package com.github.tjeukayim.commandpermissionsfabric.mixin.nbt;
+
+import com.github.tjeukayim.commandpermissionsfabric.Constants;
+import com.mojang.authlib.GameProfile;
+import me.lucko.fabric.api.permissions.v0.Permissions;
+import net.minecraft.entity.EntityType;
+import net.minecraft.entity.player.PlayerEntity;
+import net.minecraft.server.PlayerManager;
+import net.minecraft.world.World;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Redirect;
+
+@Mixin(EntityType.class)
+public abstract class EntityTypeMixin {
+
+    @Redirect(
+            method = "loadFromEntityNbt",
+            at = @At(
+                    value = "INVOKE",
+                    target = "Lnet/minecraft/server/PlayerManager;isOperator(Lcom/mojang/authlib/GameProfile;)Z"
+            )
+    )
+    private static boolean addNbtLoadEntityPermission(PlayerManager playerManager, GameProfile profile, World world, PlayerEntity playerEntity) {
+        return Permissions.check(playerEntity, Constants.NBT_LOAD_ENTITY) || playerManager.isOperator(profile);
+    }
+}

--- a/src/main/java/com/github/tjeukayim/commandpermissionsfabric/mixin/nbt/ServerPlayNetworkHandlerMixin.java
+++ b/src/main/java/com/github/tjeukayim/commandpermissionsfabric/mixin/nbt/ServerPlayNetworkHandlerMixin.java
@@ -1,0 +1,36 @@
+package com.github.tjeukayim.commandpermissionsfabric.mixin.nbt;
+
+import com.github.tjeukayim.commandpermissionsfabric.Constants;
+import me.lucko.fabric.api.permissions.v0.Permissions;
+import net.minecraft.server.network.ServerPlayNetworkHandler;
+import net.minecraft.server.network.ServerPlayerEntity;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Redirect;
+
+@Mixin(ServerPlayNetworkHandler.class)
+public abstract class ServerPlayNetworkHandlerMixin {
+
+    @Redirect(
+            method = "onQueryEntityNbt",
+            at = @At(
+                    value = "INVOKE",
+                    target = "Lnet/minecraft/server/network/ServerPlayerEntity;hasPermissionLevel(I)Z"
+            )
+    )
+    public boolean addNbtQueryEntityPermission(ServerPlayerEntity playerEntity, int level) {
+        return Permissions.check(playerEntity, Constants.NBT_QUERY_ENTITY, level);
+    }
+
+    @Redirect(
+            method = "onQueryBlockNbt",
+            at = @At(
+                    value = "INVOKE",
+                    target = "Lnet/minecraft/server/network/ServerPlayerEntity;hasPermissionLevel(I)Z"
+            )
+    )
+    public boolean addNbtQueryBlockPermission(ServerPlayerEntity playerEntity, int level) {
+        return Permissions.check(playerEntity, Constants.NBT_QUERY_BLOCK, level);
+    }
+
+}

--- a/src/main/java/com/github/tjeukayim/commandpermissionsfabric/mixin/nbt/ServerPlayNetworkHandlerMixin.java
+++ b/src/main/java/com/github/tjeukayim/commandpermissionsfabric/mixin/nbt/ServerPlayNetworkHandlerMixin.java
@@ -1,36 +1,39 @@
 package com.github.tjeukayim.commandpermissionsfabric.mixin.nbt;
 
 import com.github.tjeukayim.commandpermissionsfabric.Constants;
+import com.llamalad7.mixinextras.injector.ModifyExpressionValue;
 import me.lucko.fabric.api.permissions.v0.Permissions;
 import net.minecraft.server.network.ServerPlayNetworkHandler;
 import net.minecraft.server.network.ServerPlayerEntity;
 import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.asm.mixin.injection.At;
-import org.spongepowered.asm.mixin.injection.Redirect;
 
 @Mixin(ServerPlayNetworkHandler.class)
 public abstract class ServerPlayNetworkHandlerMixin {
 
-    @Redirect(
+    @Shadow public ServerPlayerEntity player;
+
+    @ModifyExpressionValue(
             method = "onQueryEntityNbt",
             at = @At(
                     value = "INVOKE",
                     target = "Lnet/minecraft/server/network/ServerPlayerEntity;hasPermissionLevel(I)Z"
             )
     )
-    public boolean addNbtQueryEntityPermission(ServerPlayerEntity playerEntity, int level) {
-        return Permissions.check(playerEntity, Constants.NBT_QUERY_ENTITY, level);
+    public boolean mcpf_addNbtQueryEntityPermission(boolean original) {
+        return Permissions.check(this.player, Constants.NBT_QUERY_ENTITY) || original;
     }
 
-    @Redirect(
+    @ModifyExpressionValue(
             method = "onQueryBlockNbt",
             at = @At(
                     value = "INVOKE",
                     target = "Lnet/minecraft/server/network/ServerPlayerEntity;hasPermissionLevel(I)Z"
             )
     )
-    public boolean addNbtQueryBlockPermission(ServerPlayerEntity playerEntity, int level) {
-        return Permissions.check(playerEntity, Constants.NBT_QUERY_BLOCK, level);
+    public boolean mcpf_addNbtQueryBlockPermission(boolean original) {
+        return Permissions.check(this.player, Constants.NBT_QUERY_BLOCK) || original;
     }
 
 }

--- a/src/main/java/com/github/tjeukayim/commandpermissionsfabric/mixin/operator_blocks/CommandBlockExecutorMixin.java
+++ b/src/main/java/com/github/tjeukayim/commandpermissionsfabric/mixin/operator_blocks/CommandBlockExecutorMixin.java
@@ -1,0 +1,28 @@
+package com.github.tjeukayim.commandpermissionsfabric.mixin.operator_blocks;
+
+import com.github.tjeukayim.commandpermissionsfabric.Constants;
+import me.lucko.fabric.api.permissions.v0.Permissions;
+import net.minecraft.entity.player.PlayerEntity;
+import net.minecraft.item.Items;
+import net.minecraft.world.CommandBlockExecutor;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Redirect;
+
+import static com.github.tjeukayim.commandpermissionsfabric.Constants.item;
+
+@Mixin(CommandBlockExecutor.class)
+public abstract class CommandBlockExecutorMixin {
+
+    @Redirect(
+            method = "interact",
+            at = @At(
+                    value = "INVOKE",
+                    target = "Lnet/minecraft/entity/player/PlayerEntity;isCreativeLevelTwoOp()Z"
+            )
+    )
+    public boolean addCommandBlockMinecartOpenPermission(PlayerEntity playerEntity) {
+        return Permissions.check(playerEntity, Constants.OPERATOR_BLOCK_VIEW.formatted(item(Items.COMMAND_BLOCK_MINECART))) || playerEntity.isCreativeLevelTwoOp();
+    }
+
+}

--- a/src/main/java/com/github/tjeukayim/commandpermissionsfabric/mixin/operator_blocks/CommandBlockExecutorMixin.java
+++ b/src/main/java/com/github/tjeukayim/commandpermissionsfabric/mixin/operator_blocks/CommandBlockExecutorMixin.java
@@ -1,28 +1,28 @@
 package com.github.tjeukayim.commandpermissionsfabric.mixin.operator_blocks;
 
 import com.github.tjeukayim.commandpermissionsfabric.Constants;
+import com.llamalad7.mixinextras.injector.ModifyExpressionValue;
 import me.lucko.fabric.api.permissions.v0.Permissions;
 import net.minecraft.entity.player.PlayerEntity;
 import net.minecraft.item.Items;
 import net.minecraft.world.CommandBlockExecutor;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
-import org.spongepowered.asm.mixin.injection.Redirect;
 
 import static com.github.tjeukayim.commandpermissionsfabric.Constants.item;
 
 @Mixin(CommandBlockExecutor.class)
 public abstract class CommandBlockExecutorMixin {
 
-    @Redirect(
+    @ModifyExpressionValue(
             method = "interact",
             at = @At(
                     value = "INVOKE",
                     target = "Lnet/minecraft/entity/player/PlayerEntity;isCreativeLevelTwoOp()Z"
             )
     )
-    public boolean addCommandBlockMinecartOpenPermission(PlayerEntity playerEntity) {
-        return Permissions.check(playerEntity, Constants.OPERATOR_BLOCK_VIEW.formatted(item(Items.COMMAND_BLOCK_MINECART))) || playerEntity.isCreativeLevelTwoOp();
+    public boolean mcpf_addCommandBlockMinecartOpenPermission(boolean original, PlayerEntity player) {
+        return Permissions.check(player, Constants.OPERATOR_BLOCK_VIEW.formatted(item(Items.COMMAND_BLOCK_MINECART))) || original;
     }
 
 }

--- a/src/main/java/com/github/tjeukayim/commandpermissionsfabric/mixin/operator_blocks/CommandBlockItemMixin.java
+++ b/src/main/java/com/github/tjeukayim/commandpermissionsfabric/mixin/operator_blocks/CommandBlockItemMixin.java
@@ -1,0 +1,34 @@
+package com.github.tjeukayim.commandpermissionsfabric.mixin.operator_blocks;
+
+import com.github.tjeukayim.commandpermissionsfabric.Constants;
+import me.lucko.fabric.api.permissions.v0.Permissions;
+import net.minecraft.block.Block;
+import net.minecraft.entity.player.PlayerEntity;
+import net.minecraft.item.BlockItem;
+import net.minecraft.item.CommandBlockItem;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Redirect;
+
+import static com.github.tjeukayim.commandpermissionsfabric.Constants.block;
+
+@Mixin(CommandBlockItem.class)
+public abstract class CommandBlockItemMixin extends BlockItem {
+
+    public CommandBlockItemMixin(Block block, Settings settings) {
+        super(block, settings);
+    }
+
+    // TODO: add command block minecart open permission check
+    @Redirect(
+            method = "getPlacementState",
+            at = @At(
+                    value = "INVOKE",
+                    target = "Lnet/minecraft/entity/player/PlayerEntity;isCreativeLevelTwoOp()Z"
+            )
+    )
+    public boolean addCommandBlockPlacePermission(PlayerEntity playerEntity) {
+        return Permissions.check(playerEntity, Constants.OPERATOR_BLOCK_PLACE.formatted(block(getBlock()))) || playerEntity.isCreativeLevelTwoOp();
+    }
+
+}

--- a/src/main/java/com/github/tjeukayim/commandpermissionsfabric/mixin/operator_blocks/CommandBlockItemMixin.java
+++ b/src/main/java/com/github/tjeukayim/commandpermissionsfabric/mixin/operator_blocks/CommandBlockItemMixin.java
@@ -19,7 +19,6 @@ public abstract class CommandBlockItemMixin extends BlockItem {
         super(block, settings);
     }
 
-    // TODO: add command block minecart open permission check
     @Redirect(
             method = "getPlacementState",
             at = @At(

--- a/src/main/java/com/github/tjeukayim/commandpermissionsfabric/mixin/operator_blocks/CommandBlockItemMixin.java
+++ b/src/main/java/com/github/tjeukayim/commandpermissionsfabric/mixin/operator_blocks/CommandBlockItemMixin.java
@@ -1,14 +1,14 @@
 package com.github.tjeukayim.commandpermissionsfabric.mixin.operator_blocks;
 
 import com.github.tjeukayim.commandpermissionsfabric.Constants;
+import com.llamalad7.mixinextras.injector.ModifyExpressionValue;
 import me.lucko.fabric.api.permissions.v0.Permissions;
 import net.minecraft.block.Block;
-import net.minecraft.entity.player.PlayerEntity;
 import net.minecraft.item.BlockItem;
 import net.minecraft.item.CommandBlockItem;
+import net.minecraft.item.ItemPlacementContext;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
-import org.spongepowered.asm.mixin.injection.Redirect;
 
 import static com.github.tjeukayim.commandpermissionsfabric.Constants.block;
 
@@ -19,15 +19,16 @@ public abstract class CommandBlockItemMixin extends BlockItem {
         super(block, settings);
     }
 
-    @Redirect(
+    @ModifyExpressionValue(
             method = "getPlacementState",
             at = @At(
                     value = "INVOKE",
                     target = "Lnet/minecraft/entity/player/PlayerEntity;isCreativeLevelTwoOp()Z"
             )
     )
-    public boolean addCommandBlockPlacePermission(PlayerEntity playerEntity) {
-        return Permissions.check(playerEntity, Constants.OPERATOR_BLOCK_PLACE.formatted(block(getBlock()))) || playerEntity.isCreativeLevelTwoOp();
+    public boolean mcpf_addCommandBlockPlacePermission(boolean original, ItemPlacementContext context) {
+        assert context.getPlayer() != null;
+        return Permissions.check(context.getPlayer(), Constants.OPERATOR_BLOCK_PLACE.formatted(block(getBlock()))) || original;
     }
 
 }

--- a/src/main/java/com/github/tjeukayim/commandpermissionsfabric/mixin/operator_blocks/OperatorBlockMixin.java
+++ b/src/main/java/com/github/tjeukayim/commandpermissionsfabric/mixin/operator_blocks/OperatorBlockMixin.java
@@ -1,0 +1,33 @@
+package com.github.tjeukayim.commandpermissionsfabric.mixin.operator_blocks;
+
+import com.github.tjeukayim.commandpermissionsfabric.Constants;
+import me.lucko.fabric.api.permissions.v0.Permissions;
+import net.minecraft.block.Block;
+import net.minecraft.block.CommandBlock;
+import net.minecraft.block.JigsawBlock;
+import net.minecraft.entity.player.PlayerEntity;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Redirect;
+
+import static com.github.tjeukayim.commandpermissionsfabric.Constants.block;
+
+@Mixin(value = {CommandBlock.class, JigsawBlock.class})
+public abstract class OperatorBlockMixin extends Block {
+
+    public OperatorBlockMixin(Settings settings) {
+        super(settings);
+    }
+
+    @Redirect(
+            method = "onUse",
+            at = @At(
+                    value = "INVOKE",
+                    target = "Lnet/minecraft/entity/player/PlayerEntity;isCreativeLevelTwoOp()Z"
+            )
+    )
+    public boolean addOperatorBlockEditPermission(PlayerEntity playerEntity) {
+        return Permissions.check(playerEntity, Constants.OPERATOR_BLOCK_VIEW.formatted(block(this))) || playerEntity.isCreativeLevelTwoOp();
+    }
+
+}

--- a/src/main/java/com/github/tjeukayim/commandpermissionsfabric/mixin/operator_blocks/OperatorBlockMixin.java
+++ b/src/main/java/com/github/tjeukayim/commandpermissionsfabric/mixin/operator_blocks/OperatorBlockMixin.java
@@ -1,14 +1,17 @@
 package com.github.tjeukayim.commandpermissionsfabric.mixin.operator_blocks;
 
 import com.github.tjeukayim.commandpermissionsfabric.Constants;
+import com.llamalad7.mixinextras.injector.ModifyExpressionValue;
 import me.lucko.fabric.api.permissions.v0.Permissions;
 import net.minecraft.block.Block;
+import net.minecraft.block.BlockState;
 import net.minecraft.block.CommandBlock;
 import net.minecraft.block.JigsawBlock;
 import net.minecraft.entity.player.PlayerEntity;
+import net.minecraft.util.math.BlockPos;
+import net.minecraft.world.World;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
-import org.spongepowered.asm.mixin.injection.Redirect;
 
 import static com.github.tjeukayim.commandpermissionsfabric.Constants.block;
 
@@ -19,15 +22,15 @@ public abstract class OperatorBlockMixin extends Block {
         super(settings);
     }
 
-    @Redirect(
+    @ModifyExpressionValue(
             method = "onUse",
             at = @At(
                     value = "INVOKE",
                     target = "Lnet/minecraft/entity/player/PlayerEntity;isCreativeLevelTwoOp()Z"
             )
     )
-    public boolean addOperatorBlockEditPermission(PlayerEntity playerEntity) {
-        return Permissions.check(playerEntity, Constants.OPERATOR_BLOCK_VIEW.formatted(block(this))) || playerEntity.isCreativeLevelTwoOp();
+    public boolean mcpf_addOperatorBlockEditPermission(boolean original, BlockState state, World world, BlockPos pos, PlayerEntity player) {
+        return Permissions.check(player, Constants.OPERATOR_BLOCK_VIEW.formatted(block(this))) || original;
     }
 
 }

--- a/src/main/java/com/github/tjeukayim/commandpermissionsfabric/mixin/operator_blocks/ServerPlayNetworkHandlerMixin.java
+++ b/src/main/java/com/github/tjeukayim/commandpermissionsfabric/mixin/operator_blocks/ServerPlayNetworkHandlerMixin.java
@@ -1,0 +1,74 @@
+package com.github.tjeukayim.commandpermissionsfabric.mixin.operator_blocks;
+
+import com.github.tjeukayim.commandpermissionsfabric.Constants;
+import me.lucko.fabric.api.permissions.v0.Permissions;
+import net.minecraft.block.Blocks;
+import net.minecraft.item.Items;
+import net.minecraft.server.network.ServerPlayNetworkHandler;
+import net.minecraft.server.network.ServerPlayerEntity;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Redirect;
+
+import static com.github.tjeukayim.commandpermissionsfabric.Constants.block;
+import static com.github.tjeukayim.commandpermissionsfabric.Constants.item;
+
+@Mixin(ServerPlayNetworkHandler.class)
+public abstract class ServerPlayNetworkHandlerMixin {
+
+    @Redirect(
+            method = "onUpdateCommandBlock",
+            at = @At(
+                    value = "INVOKE",
+                    target = "Lnet/minecraft/server/network/ServerPlayerEntity;isCreativeLevelTwoOp()Z"
+            )
+    )
+    public boolean addCommandBlockEditPermission(ServerPlayerEntity playerEntity) {
+        return Permissions.check(playerEntity, Constants.OPERATOR_BLOCK_EDIT.formatted(block(Blocks.COMMAND_BLOCK))) || playerEntity.isCreativeLevelTwoOp();
+    }
+
+    @Redirect(
+            method = "onUpdateJigsaw",
+            at = @At(
+                    value = "INVOKE",
+                    target = "Lnet/minecraft/server/network/ServerPlayerEntity;isCreativeLevelTwoOp()Z"
+            )
+    )
+    public boolean addJigsawBlockEditPermission(ServerPlayerEntity playerEntity) {
+        return Permissions.check(playerEntity, Constants.OPERATOR_BLOCK_EDIT.formatted(block(Blocks.JIGSAW))) || playerEntity.isCreativeLevelTwoOp();
+    }
+
+    @Redirect(
+            method = "onJigsawGenerating",
+            at = @At(
+                    value = "INVOKE",
+                    target = "Lnet/minecraft/server/network/ServerPlayerEntity;isCreativeLevelTwoOp()Z"
+            )
+    )
+    public boolean addJigsawBlockEditPermission2(ServerPlayerEntity playerEntity) {
+        return Permissions.check(playerEntity, Constants.OPERATOR_BLOCK_EDIT.formatted(block(Blocks.JIGSAW))) || playerEntity.isCreativeLevelTwoOp();
+    }
+
+    @Redirect(
+            method = "onUpdateStructureBlock",
+            at = @At(
+                    value = "INVOKE",
+                    target = "Lnet/minecraft/server/network/ServerPlayerEntity;isCreativeLevelTwoOp()Z"
+            )
+    )
+    public boolean addStructureBlockEditPermission(ServerPlayerEntity playerEntity) {
+        return Permissions.check(playerEntity, Constants.OPERATOR_BLOCK_EDIT.formatted(block(Blocks.STRUCTURE_BLOCK))) || playerEntity.isCreativeLevelTwoOp();
+    }
+
+    @Redirect(
+            method = "onUpdateCommandBlockMinecart",
+            at = @At(
+                    value = "INVOKE",
+                    target = "Lnet/minecraft/server/network/ServerPlayerEntity;isCreativeLevelTwoOp()Z"
+            )
+    )
+    public boolean addCommandBlockMinecartEditPermission(ServerPlayerEntity playerEntity) {
+        return Permissions.check(playerEntity, Constants.OPERATOR_BLOCK_EDIT.formatted(item(Items.COMMAND_BLOCK_MINECART))) || playerEntity.isCreativeLevelTwoOp();
+    }
+
+}

--- a/src/main/java/com/github/tjeukayim/commandpermissionsfabric/mixin/operator_blocks/ServerPlayNetworkHandlerMixin.java
+++ b/src/main/java/com/github/tjeukayim/commandpermissionsfabric/mixin/operator_blocks/ServerPlayNetworkHandlerMixin.java
@@ -1,14 +1,15 @@
 package com.github.tjeukayim.commandpermissionsfabric.mixin.operator_blocks;
 
 import com.github.tjeukayim.commandpermissionsfabric.Constants;
+import com.llamalad7.mixinextras.injector.ModifyExpressionValue;
 import me.lucko.fabric.api.permissions.v0.Permissions;
 import net.minecraft.block.Blocks;
 import net.minecraft.item.Items;
 import net.minecraft.server.network.ServerPlayNetworkHandler;
 import net.minecraft.server.network.ServerPlayerEntity;
 import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.asm.mixin.injection.At;
-import org.spongepowered.asm.mixin.injection.Redirect;
 
 import static com.github.tjeukayim.commandpermissionsfabric.Constants.block;
 import static com.github.tjeukayim.commandpermissionsfabric.Constants.item;
@@ -16,59 +17,61 @@ import static com.github.tjeukayim.commandpermissionsfabric.Constants.item;
 @Mixin(ServerPlayNetworkHandler.class)
 public abstract class ServerPlayNetworkHandlerMixin {
 
-    @Redirect(
+    @Shadow public ServerPlayerEntity player;
+
+    @ModifyExpressionValue(
             method = "onUpdateCommandBlock",
             at = @At(
                     value = "INVOKE",
                     target = "Lnet/minecraft/server/network/ServerPlayerEntity;isCreativeLevelTwoOp()Z"
             )
     )
-    public boolean addCommandBlockEditPermission(ServerPlayerEntity playerEntity) {
-        return Permissions.check(playerEntity, Constants.OPERATOR_BLOCK_EDIT.formatted(block(Blocks.COMMAND_BLOCK))) || playerEntity.isCreativeLevelTwoOp();
+    public boolean mcpf_addCommandBlockEditPermission(boolean original) {
+        return Permissions.check(this.player, Constants.OPERATOR_BLOCK_EDIT.formatted(block(Blocks.COMMAND_BLOCK))) || original;
     }
 
-    @Redirect(
+    @ModifyExpressionValue(
             method = "onUpdateJigsaw",
             at = @At(
                     value = "INVOKE",
                     target = "Lnet/minecraft/server/network/ServerPlayerEntity;isCreativeLevelTwoOp()Z"
             )
     )
-    public boolean addJigsawBlockEditPermission(ServerPlayerEntity playerEntity) {
-        return Permissions.check(playerEntity, Constants.OPERATOR_BLOCK_EDIT.formatted(block(Blocks.JIGSAW))) || playerEntity.isCreativeLevelTwoOp();
+    public boolean mcpf_addJigsawBlockEditPermission(boolean original) {
+        return Permissions.check(this.player, Constants.OPERATOR_BLOCK_EDIT.formatted(block(Blocks.JIGSAW))) || original;
     }
 
-    @Redirect(
+    @ModifyExpressionValue(
             method = "onJigsawGenerating",
             at = @At(
                     value = "INVOKE",
                     target = "Lnet/minecraft/server/network/ServerPlayerEntity;isCreativeLevelTwoOp()Z"
             )
     )
-    public boolean addJigsawBlockEditPermission2(ServerPlayerEntity playerEntity) {
-        return Permissions.check(playerEntity, Constants.OPERATOR_BLOCK_EDIT.formatted(block(Blocks.JIGSAW))) || playerEntity.isCreativeLevelTwoOp();
+    public boolean mcpf_addJigsawBlockEditPermission2(boolean original) {
+        return Permissions.check(this.player, Constants.OPERATOR_BLOCK_EDIT.formatted(block(Blocks.JIGSAW))) || original;
     }
 
-    @Redirect(
+    @ModifyExpressionValue(
             method = "onUpdateStructureBlock",
             at = @At(
                     value = "INVOKE",
                     target = "Lnet/minecraft/server/network/ServerPlayerEntity;isCreativeLevelTwoOp()Z"
             )
     )
-    public boolean addStructureBlockEditPermission(ServerPlayerEntity playerEntity) {
-        return Permissions.check(playerEntity, Constants.OPERATOR_BLOCK_EDIT.formatted(block(Blocks.STRUCTURE_BLOCK))) || playerEntity.isCreativeLevelTwoOp();
+    public boolean mcpf_addStructureBlockEditPermission(boolean original) {
+        return Permissions.check(this.player, Constants.OPERATOR_BLOCK_EDIT.formatted(block(Blocks.STRUCTURE_BLOCK))) || original;
     }
 
-    @Redirect(
+    @ModifyExpressionValue(
             method = "onUpdateCommandBlockMinecart",
             at = @At(
                     value = "INVOKE",
                     target = "Lnet/minecraft/server/network/ServerPlayerEntity;isCreativeLevelTwoOp()Z"
             )
     )
-    public boolean addCommandBlockMinecartEditPermission(ServerPlayerEntity playerEntity) {
-        return Permissions.check(playerEntity, Constants.OPERATOR_BLOCK_EDIT.formatted(item(Items.COMMAND_BLOCK_MINECART))) || playerEntity.isCreativeLevelTwoOp();
+    public boolean mcpf_addCommandBlockMinecartEditPermission(boolean original) {
+        return Permissions.check(this.player, Constants.OPERATOR_BLOCK_EDIT.formatted(item(Items.COMMAND_BLOCK_MINECART))) || original;
     }
 
 }

--- a/src/main/java/com/github/tjeukayim/commandpermissionsfabric/mixin/operator_blocks/ServerPlayerInteractionManagerMixin.java
+++ b/src/main/java/com/github/tjeukayim/commandpermissionsfabric/mixin/operator_blocks/ServerPlayerInteractionManagerMixin.java
@@ -1,0 +1,31 @@
+package com.github.tjeukayim.commandpermissionsfabric.mixin.operator_blocks;
+
+import com.github.tjeukayim.commandpermissionsfabric.Constants;
+import me.lucko.fabric.api.permissions.v0.Permissions;
+import net.minecraft.server.network.ServerPlayerEntity;
+import net.minecraft.server.network.ServerPlayerInteractionManager;
+import net.minecraft.server.world.ServerWorld;
+import net.minecraft.util.math.BlockPos;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Redirect;
+
+import static com.github.tjeukayim.commandpermissionsfabric.Constants.block;
+
+@Mixin(ServerPlayerInteractionManager.class)
+public abstract class ServerPlayerInteractionManagerMixin {
+
+    @Shadow protected ServerWorld world;
+
+    @Redirect(
+            method = "tryBreakBlock",
+            at = @At(
+                    value = "INVOKE",
+                    target = "Lnet/minecraft/server/network/ServerPlayerEntity;isCreativeLevelTwoOp()Z"
+            )
+    )
+    public boolean addOperatorBlockBreakPermission(ServerPlayerEntity playerEntity, BlockPos pos) {
+        return Permissions.check(playerEntity, Constants.OPERATOR_BLOCK_BREAK.formatted(block(this.world.getBlockState(pos).getBlock()))) || playerEntity.isCreativeLevelTwoOp();
+    }
+}

--- a/src/main/java/com/github/tjeukayim/commandpermissionsfabric/mixin/operator_blocks/ServerPlayerInteractionManagerMixin.java
+++ b/src/main/java/com/github/tjeukayim/commandpermissionsfabric/mixin/operator_blocks/ServerPlayerInteractionManagerMixin.java
@@ -1,31 +1,37 @@
 package com.github.tjeukayim.commandpermissionsfabric.mixin.operator_blocks;
 
 import com.github.tjeukayim.commandpermissionsfabric.Constants;
+import com.llamalad7.mixinextras.injector.ModifyExpressionValue;
 import me.lucko.fabric.api.permissions.v0.Permissions;
 import net.minecraft.server.network.ServerPlayerEntity;
 import net.minecraft.server.network.ServerPlayerInteractionManager;
 import net.minecraft.server.world.ServerWorld;
 import net.minecraft.util.math.BlockPos;
+import org.spongepowered.asm.mixin.Final;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.asm.mixin.injection.At;
-import org.spongepowered.asm.mixin.injection.Redirect;
 
 import static com.github.tjeukayim.commandpermissionsfabric.Constants.block;
 
 @Mixin(ServerPlayerInteractionManager.class)
 public abstract class ServerPlayerInteractionManagerMixin {
 
-    @Shadow protected ServerWorld world;
+    @Shadow
+    protected ServerWorld world;
 
-    @Redirect(
+    @Shadow
+    @Final
+    protected ServerPlayerEntity player;
+
+    @ModifyExpressionValue(
             method = "tryBreakBlock",
             at = @At(
                     value = "INVOKE",
                     target = "Lnet/minecraft/server/network/ServerPlayerEntity;isCreativeLevelTwoOp()Z"
             )
     )
-    public boolean addOperatorBlockBreakPermission(ServerPlayerEntity playerEntity, BlockPos pos) {
-        return Permissions.check(playerEntity, Constants.OPERATOR_BLOCK_BREAK.formatted(block(this.world.getBlockState(pos).getBlock()))) || playerEntity.isCreativeLevelTwoOp();
+    public boolean mcpf_addOperatorBlockBreakPermission(boolean original, BlockPos pos) {
+        return Permissions.check(this.player, Constants.OPERATOR_BLOCK_BREAK.formatted(block(this.world.getBlockState(pos).getBlock()))) || original;
     }
 }

--- a/src/main/java/com/github/tjeukayim/commandpermissionsfabric/mixin/operator_blocks/StructureBlockBlockEntityMixin.java
+++ b/src/main/java/com/github/tjeukayim/commandpermissionsfabric/mixin/operator_blocks/StructureBlockBlockEntityMixin.java
@@ -1,0 +1,28 @@
+package com.github.tjeukayim.commandpermissionsfabric.mixin.operator_blocks;
+
+import com.github.tjeukayim.commandpermissionsfabric.Constants;
+import me.lucko.fabric.api.permissions.v0.Permissions;
+import net.minecraft.block.Blocks;
+import net.minecraft.block.entity.StructureBlockBlockEntity;
+import net.minecraft.entity.player.PlayerEntity;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Redirect;
+
+import static com.github.tjeukayim.commandpermissionsfabric.Constants.block;
+
+@Mixin(StructureBlockBlockEntity.class)
+public abstract class StructureBlockBlockEntityMixin {
+
+    @Redirect(
+            method = "openScreen",
+            at = @At(
+                    value = "INVOKE",
+                    target = "Lnet/minecraft/entity/player/PlayerEntity;isCreativeLevelTwoOp()Z"
+            )
+    )
+    public boolean addCommandBlockEditPermission(PlayerEntity playerEntity) {
+        return Permissions.check(playerEntity, Constants.OPERATOR_BLOCK_VIEW.formatted(block(Blocks.STRUCTURE_BLOCK))) || playerEntity.isCreativeLevelTwoOp();
+    }
+
+}

--- a/src/main/java/com/github/tjeukayim/commandpermissionsfabric/mixin/operator_blocks/StructureBlockBlockEntityMixin.java
+++ b/src/main/java/com/github/tjeukayim/commandpermissionsfabric/mixin/operator_blocks/StructureBlockBlockEntityMixin.java
@@ -1,28 +1,28 @@
 package com.github.tjeukayim.commandpermissionsfabric.mixin.operator_blocks;
 
 import com.github.tjeukayim.commandpermissionsfabric.Constants;
+import com.llamalad7.mixinextras.injector.ModifyExpressionValue;
 import me.lucko.fabric.api.permissions.v0.Permissions;
 import net.minecraft.block.Blocks;
 import net.minecraft.block.entity.StructureBlockBlockEntity;
 import net.minecraft.entity.player.PlayerEntity;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
-import org.spongepowered.asm.mixin.injection.Redirect;
 
 import static com.github.tjeukayim.commandpermissionsfabric.Constants.block;
 
 @Mixin(StructureBlockBlockEntity.class)
 public abstract class StructureBlockBlockEntityMixin {
 
-    @Redirect(
+    @ModifyExpressionValue(
             method = "openScreen",
             at = @At(
                     value = "INVOKE",
                     target = "Lnet/minecraft/entity/player/PlayerEntity;isCreativeLevelTwoOp()Z"
             )
     )
-    public boolean addCommandBlockEditPermission(PlayerEntity playerEntity) {
-        return Permissions.check(playerEntity, Constants.OPERATOR_BLOCK_VIEW.formatted(block(Blocks.STRUCTURE_BLOCK))) || playerEntity.isCreativeLevelTwoOp();
+    public boolean mcpf_addCommandBlockEditPermission(boolean original, PlayerEntity player) {
+        return Permissions.check(player, Constants.OPERATOR_BLOCK_VIEW.formatted(block(Blocks.STRUCTURE_BLOCK))) || original;
     }
 
 }

--- a/src/main/java/com/github/tjeukayim/commandpermissionsfabric/mixin/selector/EntityArgumentTypeMixin.java
+++ b/src/main/java/com/github/tjeukayim/commandpermissionsfabric/mixin/selector/EntityArgumentTypeMixin.java
@@ -1,6 +1,8 @@
 package com.github.tjeukayim.commandpermissionsfabric.mixin.selector;
 
 import com.github.tjeukayim.commandpermissionsfabric.Constants;
+import com.llamalad7.mixinextras.injector.ModifyExpressionValue;
+import com.mojang.brigadier.context.CommandContext;
 import me.lucko.fabric.api.permissions.v0.Permissions;
 import net.minecraft.command.CommandSource;
 import net.minecraft.command.argument.EntityArgumentType;
@@ -11,15 +13,15 @@ import org.spongepowered.asm.mixin.injection.Redirect;
 @Mixin(EntityArgumentType.class)
 public abstract class EntityArgumentTypeMixin {
 
-    @Redirect(
+    @ModifyExpressionValue(
             method = "listSuggestions",
             at = @At(
                     value = "INVOKE",
                     target = "Lnet/minecraft/command/CommandSource;hasPermissionLevel(I)Z"
             )
     )
-    public boolean addSelectorPermission(CommandSource source, int level) {
-        return Permissions.check(source, Constants.SELECTOR, level);
+    public boolean mcpf_addSelectorPermission(boolean original, CommandContext<CommandSource> context) {
+        return Permissions.check(context.getSource(), Constants.SELECTOR) || original;
     }
 
 }

--- a/src/main/java/com/github/tjeukayim/commandpermissionsfabric/mixin/selector/EntityArgumentTypeMixin.java
+++ b/src/main/java/com/github/tjeukayim/commandpermissionsfabric/mixin/selector/EntityArgumentTypeMixin.java
@@ -1,0 +1,25 @@
+package com.github.tjeukayim.commandpermissionsfabric.mixin.selector;
+
+import com.github.tjeukayim.commandpermissionsfabric.Constants;
+import me.lucko.fabric.api.permissions.v0.Permissions;
+import net.minecraft.command.CommandSource;
+import net.minecraft.command.argument.EntityArgumentType;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Redirect;
+
+@Mixin(EntityArgumentType.class)
+public abstract class EntityArgumentTypeMixin {
+
+    @Redirect(
+            method = "listSuggestions",
+            at = @At(
+                    value = "INVOKE",
+                    target = "Lnet/minecraft/command/CommandSource;hasPermissionLevel(I)Z"
+            )
+    )
+    public boolean addSelectorPermission(CommandSource source, int level) {
+        return Permissions.check(source, Constants.SELECTOR, level);
+    }
+
+}

--- a/src/main/java/com/github/tjeukayim/commandpermissionsfabric/mixin/selector/EntitySelectorMixin.java
+++ b/src/main/java/com/github/tjeukayim/commandpermissionsfabric/mixin/selector/EntitySelectorMixin.java
@@ -1,6 +1,7 @@
 package com.github.tjeukayim.commandpermissionsfabric.mixin.selector;
 
 import com.github.tjeukayim.commandpermissionsfabric.Constants;
+import com.llamalad7.mixinextras.injector.ModifyExpressionValue;
 import me.lucko.fabric.api.permissions.v0.Permissions;
 import net.minecraft.command.EntitySelector;
 import net.minecraft.server.command.ServerCommandSource;
@@ -11,15 +12,15 @@ import org.spongepowered.asm.mixin.injection.Redirect;
 @Mixin(EntitySelector.class)
 public abstract class EntitySelectorMixin {
 
-    @Redirect(
+    @ModifyExpressionValue(
             method = "checkSourcePermission",
             at = @At(
                     value = "INVOKE",
                     target = "Lnet/minecraft/server/command/ServerCommandSource;hasPermissionLevel(I)Z"
             )
     )
-    public boolean addSelectorPermission(ServerCommandSource source, int level) {
-        return Permissions.check(source, Constants.SELECTOR, level);
+    public boolean mcpf_addSelectorPermission(boolean original, ServerCommandSource source) {
+        return Permissions.check(source, Constants.SELECTOR) || original;
     }
 
 }

--- a/src/main/java/com/github/tjeukayim/commandpermissionsfabric/mixin/selector/EntitySelectorMixin.java
+++ b/src/main/java/com/github/tjeukayim/commandpermissionsfabric/mixin/selector/EntitySelectorMixin.java
@@ -1,0 +1,25 @@
+package com.github.tjeukayim.commandpermissionsfabric.mixin.selector;
+
+import com.github.tjeukayim.commandpermissionsfabric.Constants;
+import me.lucko.fabric.api.permissions.v0.Permissions;
+import net.minecraft.command.EntitySelector;
+import net.minecraft.server.command.ServerCommandSource;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Redirect;
+
+@Mixin(EntitySelector.class)
+public abstract class EntitySelectorMixin {
+
+    @Redirect(
+            method = "checkSourcePermission",
+            at = @At(
+                    value = "INVOKE",
+                    target = "Lnet/minecraft/server/command/ServerCommandSource;hasPermissionLevel(I)Z"
+            )
+    )
+    public boolean addSelectorPermission(ServerCommandSource source, int level) {
+        return Permissions.check(source, Constants.SELECTOR, level);
+    }
+
+}

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -19,12 +19,14 @@
   "entrypoints": {
     "server": [
       "com.github.tjeukayim.commandpermissionsfabric.PermissionsMod"
+    ],
+    "preLaunch": [
+      "com.llamalad7.mixinextras.MixinExtrasBootstrap::init"
     ]
   },
   "mixins": [
     "mcpf.mixins.json"
   ],
-
   "depends": {
     "fabricloader": ">=0.12.8",
     "fabric-command-api-v2": "*",

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -17,7 +17,7 @@
 
   "environment": "*",
   "entrypoints": {
-    "main": [
+    "server": [
       "com.github.tjeukayim.commandpermissionsfabric.PermissionsMod"
     ]
   },

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -22,6 +22,7 @@
     ]
   },
   "mixins": [
+    "mcpf.mixins.json"
   ],
 
   "depends": {

--- a/src/main/resources/mcpf.accesswidener
+++ b/src/main/resources/mcpf.accesswidener
@@ -1,0 +1,2 @@
+accessWidener	v1	named
+accessible    class    net/minecraft/server/command/ExecuteCommand$Condition

--- a/src/main/resources/mcpf.mixins.json
+++ b/src/main/resources/mcpf.mixins.json
@@ -7,6 +7,24 @@
     "defaultRequire": 1
   },
   "server": [
-    "ExecuteCommandMixin"
+    "ExecuteCommandMixin",
+    "PlayerManagerMixin",
+    "bypass.chat_speed.ServerPlayNetworkHandlerMixin",
+    "bypass.force_gamemode.DefaultGameModeCommandMixin",
+    "bypass.force_gamemode.ServerPlayerEntityMixin",
+    "bypass.move_speed.ServerPlayNetworkHandlerMixin",
+    "bypass.spawn_protection.MinecraftDedicatedServerMixin",
+    "debugstick.DebugStickItemMixin",
+    "nbt.BlockItemMixin",
+    "nbt.EntityTypeMixin",
+    "nbt.ServerPlayNetworkHandlerMixin",
+    "operator_blocks.CommandBlockExecutorMixin",
+    "operator_blocks.CommandBlockItemMixin",
+    "operator_blocks.OperatorBlockMixin",
+    "operator_blocks.ServerPlayerInteractionManagerMixin",
+    "operator_blocks.ServerPlayNetworkHandlerMixin",
+    "operator_blocks.StructureBlockBlockEntityMixin",
+    "selector.EntityArgumentTypeMixin",
+    "selector.EntitySelectorMixin"
   ]
 }

--- a/src/main/resources/mcpf.mixins.json
+++ b/src/main/resources/mcpf.mixins.json
@@ -1,0 +1,12 @@
+{
+  "required": true,
+  "minVersion": "0.8",
+  "package": "com.github.tjeukayim.commandpermissionsfabric.mixin",
+  "compatibilityLevel": "JAVA_17",
+  "injectors": {
+    "defaultRequire": 1
+  },
+  "server": [
+    "ExecuteCommandMixin"
+  ]
+}

--- a/src/main/resources/mcpf.mixins.json
+++ b/src/main/resources/mcpf.mixins.json
@@ -7,6 +7,7 @@
     "defaultRequire": 1
   },
   "server": [
+    "CommandNodeAccessor",
     "ExecuteCommandMixin",
     "PlayerManagerMixin",
     "bypass.chat_speed.ServerPlayNetworkHandlerMixin",


### PR DESCRIPTION
Hey, I don't know if this is within the scope of this project, but I have implemented the following things (which I would like to see added):
- Added a permission condition to the vanilla `/execute` command (which checks one entity for one permission) to allow data packs to interact with permissions.
- Added most of these permissions: [PEX](https://github.com/PEXPlugins/PermissionsEx/blob/master/doc/platforms/fabric.md) (resolves #13)
- Added command node permissions (resolves #14)

If this is within the scope and gets merged, these things would need to be resolved:

- [ ] Readme needs to be adjusted for the mentioned changed
- [ ] Add support for bypassing whitelist and player limit permissions #9 (This requires some kind of offline permission checking because these things are checked before the player instance is constructed). I don't know if it's reasonable to do something like this 13f7ff757445aa9515febbf7f0f71d7fec318240 or if the current permission API just doesn't support "offline" checking.

Kind regards,
Drex